### PR TITLE
camera/media: Revert memory leak fix for targets with updated HAL+blobs

### DIFF
--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -149,6 +149,10 @@ ifeq ($(strip $(TARGET_DISABLE_OMX_VIDEO_CROP_OUTPUT)),true)
 LOCAL_CFLAGS += -DDISABLE_OMX_VIDEO_CROP_OUTPUT
 endif
 
+ifneq ($(TARGET_CAM_REQ_LEAK_FIX),false)
+LOCAL_CFLAG += -DTARGET_CAM_REQ_LEAK_FIX
+endif
+
 LOCAL_CLANG := true
 LOCAL_SANITIZE := unsigned-integer-overflow signed-integer-overflow
 

--- a/media/libstagefright/CameraSource.cpp
+++ b/media/libstagefright/CameraSource.cpp
@@ -1142,6 +1142,12 @@ void CameraSource::releaseRecordingFrameHandle(native_handle_t* handle) {
         native_handle_close(handle);
         native_handle_delete(handle);
     }
+    #ifdef TARGET_CAM_REQ_LEAK_FIX
+    else {
+        native_handle_close(handle);
+        native_handle_delete(handle);
+    }
+    #endif
 }
 
 void CameraSource::recordingFrameHandleCallbackTimestamp(int64_t timestampUs,

--- a/services/camera/libcameraservice/Android.mk
+++ b/services/camera/libcameraservice/Android.mk
@@ -86,4 +86,8 @@ endif
 
 LOCAL_MODULE:= libcameraservice
 
+ifneq ($(TARGET_CAM_REQ_LEAK_FIX),false)
+LOCAL_CFLAG += -DTARGET_CAM_REQ_LEAK_FIX
+endif
+
 include $(BUILD_SHARED_LIBRARY)

--- a/services/camera/libcameraservice/api1/CameraClient.cpp
+++ b/services/camera/libcameraservice/api1/CameraClient.cpp
@@ -524,8 +524,10 @@ void CameraClient::releaseRecordingFrameHandle(native_handle_t *handle) {
 
     mHardware->releaseRecordingFrame(dataPtr);
 
+    #ifdef TARGET_CAM_REQ_LEAK_FIX
     native_handle_close(handle);
     native_handle_delete(handle);
+    #endif
 }
 
 status_t CameraClient::setVideoBufferMode(int32_t videoBufferMode) {


### PR DESCRIPTION
Revert commit https://github.com/omnirom/android_frameworks_av/commit/9501a1e1ff0a173cd85c59723ba458d07e1fca96
for targets with updated HAL+blobs (e.g. seed)

Originally introduced in https://gerrit.omnirom.org/#/c/19939/

Change-Id: Icaae2772592eb3d1e74071f91fd6259b1662a9de